### PR TITLE
fix broken directories in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 project(silicon)
 
 file(READ ${CMAKE_SOURCE_DIR}/client_templates/javascript.js JAVASCRIPT_CLIENT_TEMPLATE)
-configure_file(${CMAKE_SOURCE_DIR}/silicon/client_templates/javascript.hh.in
-               ${CMAKE_SOURCE_DIR}/silicon/client_templates/javascript.hh)
+configure_file(${CMAKE_SOURCE_DIR}/silicon/clients/templates/javascript.hh.in
+               ${CMAKE_SOURCE_DIR}/silicon/clients/templates/javascript.hh)
 
 file(READ ${CMAKE_SOURCE_DIR}/client_templates/websocket.js JAVASCRIPT_WS_CLIENT_TEMPLATE)
 configure_file(${CMAKE_SOURCE_DIR}/silicon/clients/templates/javascript_websocket.hh.in


### PR DESCRIPTION
This didn't build as is from a fresh clone.  I don't know much about modern C++ but making these changes fixed the install.sh script.  Hope they're the right thing to do.  If not, feel free to delete the PR.

Arch Linux, GNU 4.9.2