### PR TITLE
changed CMake directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 *.exe
 *.out
 *.app
+
+# Biicode
+bii/
+bin/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,13 @@ IF(BIICODE)
   #
 
 
-  file(READ ${CMAKE_SOURCE_DIR}/client_templates/javascript.js JAVASCRIPT_CLIENT_TEMPLATE)
-  configure_file(${CMAKE_SOURCE_DIR}/silicon/clients/templates/javascript.hh.in
-                 ${CMAKE_BINARY_DIR}/silicon/clients/templates/javascript.hh)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/client_templates/javascript.js JAVASCRIPT_CLIENT_TEMPLATE)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/silicon/clients/templates/javascript.hh.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/silicon/clients/templates/javascript.hh)
 
-  file(READ ${CMAKE_SOURCE_DIR}/client_templates/websocket.js JAVASCRIPT_WS_CLIENT_TEMPLATE)
-  configure_file(${CMAKE_SOURCE_DIR}/silicon/clients/templates/javascript_websocket.hh.in
-                 ${CMAKE_BINARY_DIR}/silicon/clients/templates/javascript_websocket.hh)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/client_templates/websocket.js JAVASCRIPT_WS_CLIENT_TEMPLATE)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/silicon/clients/templates/javascript_websocket.hh.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/silicon/clients/templates/javascript_websocket.hh)
 
   ADD_BIICODE_TARGETS()
 


### PR DESCRIPTION
The problem seems that using CMAKE_SRC_DIR is typically not a good idea, depending on how the project and cmake is managed, it can change. The same applies to the BIN dir. Using CMAKE_CURRENT_SRC_DIR refers to the directory in which this CMake lives, which I would say that is the intended dir.