### PR TITLE
Add iostream header

### DIFF
--- a/silicon/middlewares/sql_orm.hh
+++ b/silicon/middlewares/sql_orm.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <sstream>
 #include <iod/utils.hh>
 #include <silicon/symbols.hh>


### PR DESCRIPTION
Necessary because of `std:cout` use in line 212
