### PR TITLE
update mhd.hh with correct EPOLL flag

### DIFF
--- a/silicon/backends/mhd.hh
+++ b/silicon/backends/mhd.hh
@@ -452,7 +452,7 @@ namespace sl
     else if (options.has(_select))
       flags = MHD_USE_SELECT_INTERNALLY;
     else if (options.has(_linux_epoll))
-      flags = MHD_USE_EPOLL_INTERNALLY;
+      flags = MHD_USE_EPOLL_LINUX_ONLY;
 
     int thread_pool_size = options.get(_nthreads, std::thread::hardware_concurrency());
 


### PR DESCRIPTION
I've seen in the history that this has gone through a few iterations.
Both `MHD_USE_EPOLL_INTERNALLY_LINUX_ONLY` and `MHD_USE_EPOLL_INTERALLY` were incorrect. This fixes the issue.