### PR TITLE
the 'usleep' function is defined in 'unistd.h' in MinGW toolchain

### DIFF
--- a/silicon/backends/mhd.hh
+++ b/silicon/backends/mhd.hh
@@ -13,6 +13,10 @@
 #include <string.h>
 #include <stdio.h>
 
+#if defined(__GNUC__) && defined(__MINGW32__)
+#include <unistd.h>
+#endif
+
 #include <iod/json.hh>
 #include <iod/utils.hh>
 


### PR DESCRIPTION
when building the `hello world example` using a mingw toolchain, faild with no definition for `usleep`.
do some searching found that the `usleep` is defined in `unistd.h`.
after add the block
```c
#if defined(__GNUC__) && defined(__MINGW32__)
#include <unistd.h>
#endif
```
build passed and run as expect.